### PR TITLE
[220811] 안효관

### DIFF
--- a/ahg/220811/AddBracket.java
+++ b/ahg/220811/AddBracket.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+	// 괄호쌍의 부분집합문제
+    // 반드시 괄호 안의 연산자는 한개만 있어야 한다
+	static String[] num_list;
+	static int max_value = Integer.MIN_VALUE;
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st;
+		int N = Integer.parseInt(br.readLine());
+		num_list = br.readLine().split("");
+		check(num_list,0,0,3);
+		bw.write(String.valueOf(max_value));
+		bw.flush();
+	}
+
+	static void check(String[] result,int idx,int x,int y) { // 괄호 쌍을 설치 할지 안할지의 부분집합 , x는 괄호의 시작 좌표 , y는 괄호가 닫히는 좌표
+		if (y > result.length) { // 끝 괄호가 문자열 전체 길이를 초과 할 경우 연산 진행
+			int total=Integer.valueOf(result[0]);
+			for(int i = 1; i <result.length-1;i+=2) {
+				switch(result[i]) {
+				case "+":
+					total+=Integer.valueOf(result[i+1]);
+					continue;
+				case "-":
+					total-=Integer.valueOf(result[i+1]);
+					continue;
+				case "*":
+					total*=Integer.valueOf(result[i+1]);
+					continue;
+				}
+			}
+			if(max_value<total) {
+				max_value=total;
+			}
+			return;
+		}
+		check(result,idx+1,x+2,y+2); //현재 위치에 괄호를 집어 넣지 않았을때는 현재위치로부터 연산자 + 숫자 인덱스인 +2를 해줌
+		String[] result2=calc(result,x); // 괄호를 넣었다고 가정하고 현재 인덱스와 그 다음 숫자와 연산을 진행해줌
+		check(result2,idx+1,x+2,y+2); // 연산한 문자열(괄호를 넣었다고 판단)을 재귀
+	}
+
+	static String[] calc(String[] result,int x) { // 연산 진행
+		String[] num_list_2= new String[result.length-2];
+		for(int i = 0 ; i <x ; i++) {
+			num_list_2[i]=result[i];
+		}
+		int a = Integer.valueOf(result[x]);
+		int b = Integer.valueOf(result[x+2]);
+		switch(result[x+1]) {
+		case "+":
+			num_list_2[x]=String.valueOf(a+b);
+			break;
+		case "-":
+			num_list_2[x]=String.valueOf(a-b);
+			break;
+		case "*":
+			num_list_2[x]=String.valueOf(a*b);
+			break;
+		}
+		for(int i = x+1 ; i <num_list_2.length ; i++) {
+			num_list_2[i]=result[i+2];
+		}
+		return num_list_2;
+	}
+}

--- a/ahg/220811/Baseball.java
+++ b/ahg/220811/Baseball.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+class Player {
+	int number;
+	int value;
+
+	public Player(int number, int value) {
+		this.number = number;
+		this.value = value;
+	}
+}
+
+public class Main {
+	static int max_value = Integer.MIN_VALUE;
+	static int[][] stage;
+	static int inning;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		inning = Integer.parseInt(br.readLine());
+		stage = new int[inning][9];
+		for (int i = 0; i < inning; i++) {
+			stage[i] = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+		}
+		int[] order = new int[9];
+		boolean[] check = new boolean[10];
+		check[3] = true; // 야구 선수를 배치했는지 확인하기 위한 배열
+		order[3] = 1; // 1번 선수는 반드시 4번타자여야 하기때문에 미리 설정
+		check(order, check, 2);
+		System.out.println(max_value);
+	}
+
+	static void check(int[] order, boolean[] check, int idx) { // 타자 경우의 수를 도출하는 순열 메서드
+		if (idx == 10) {
+			baseball(order, 0, 0, 0); // 조합이 짜졌다면 경기 시작
+			return;
+		}
+		for (int i = 0; i < 9; i++) {
+			if (!check[i]) {
+				check[i] = true; 
+				order[i] = idx;
+				check(order, check, idx + 1);
+				check[i] = false;
+			}
+		}
+	}
+
+	static void baseball(int[] order, int inning_2, int i, int score) {
+		int cnt = 0;
+		int[] map = new int[3];
+		while (true) {
+			if (i > 8) // 타자가 한바퀴 돌면 다시 처음부터
+				i = 0;
+			if (stage[inning_2][order[i] - 1] == 0) { // 해당 타자의 점수를 확인하고 아웃을 증가 시켜줌 , 아웃이 세번일 경우 탈출
+				cnt++;
+				if (cnt == 3) {
+					break;
+				}
+			}
+			if (stage[inning_2][order[i] - 1] > 0) { // 현재 타자가 1점이상을 쳤을 때
+				for (int j = 0; j < stage[inning_2][order[i] - 1]; j++) { //각자 타석에 있던 주자들을 점수만큼 반복시켜주면서 1씩 올려줌
+					score += map[2];
+					map[2] = map[1];
+					map[1] = map[0];
+					map[0] = 0;
+				}
+				if (stage[inning_2][order[i]-1] ==4) { // 현재 타자는 홈런을 쳤을 경우 바로 점수 +1
+					score++;
+				}else {
+					map[stage[inning_2][order[i] - 1]-1]++; // 아닐 경우 점수 -1 만큼의 위치에 이동시켜줌
+				}
+			}
+			i++;
+		}
+
+		if (inning_2 + 1 == inning) { // 이닝 수가 종료되면 최대값 비교
+			if (max_value < score) {
+				max_value = score;
+			}
+			return;
+		}
+		baseball(order, inning_2 + 1, i + 1, score); // 다음 이닝떄는 다음 타자부터 해야하니까 i+1로 재귀 돌림
+	}
+}

--- a/ahg/220811/CastleDefense.java
+++ b/ahg/220811/CastleDefense.java
@@ -1,0 +1,141 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+class Enemy {
+	int x;
+	int y;
+
+	public Enemy(int x, int y) {
+		this.x = x;
+		this.y = y;
+	}
+}
+
+class Archer {
+	int x;
+	int y;
+
+	public Archer(int x, int y) {
+		this.x = x;
+		this.y = y;
+	}
+}
+
+public class Main {
+	// 격자판의 N번행 바로 아래(N+1번행)의 모든 칸에는 성이 있다
+	// 궁수는 성이 있는 칸에 배치할 수 있음 -> 하나의 칸에는 하나의 궁수만 존재 가능
+	// 턴마다 궁수는 적 하나 공격가능 또한 모든 궁수가 동시 공격 (같은 공격이 겹칠 수 있음 -> 맞는 사람 좀 불쌍한듯)
+	// 궁수가 공격하는 사람은 거리가 D이하인 적중 가장 가까운 적 -> 8방탐색?
+	// 여럿일 경우엔 가장 왼쪽에 있는 적 공격 --??
+	// 공격받은 적은 게임에서 제외
+	// 궁수 턴 끝나면 적 아레로 한 칸 이동 , 성이 있는 칸으로 갔을 경우 사망처리
+	// 모든 적이 맵에서 사망하면 게임 끝
+	// 격자판이 주어졋을때, 궁수의 공격으로 제거 할 수 있는 적의 최대 수 계산
+	// 궁수가 '동시'에 공격한다는것을 보니 아마 bfs 문제가 아닐까 생각함 (dfs를 사용할 경우 중복이 발생할 가능성이 있음)
+	// 문제 요약 ->턴 마다 적을 죽이는 시스템을 구현하고 그것을 조합 돌려서 최상의 결과를 뽑아라
+	static int[][] map; // 맵 정보를 담을 좌표
+	static int N, M, D;
+	static ArrayList<Enemy> eCount_3; // 적 좌표를 담은 리스트
+	static int max_kill = Integer.MIN_VALUE; 
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		D = Integer.parseInt(st.nextToken());
+		eCount_3 = new ArrayList<>();
+		map = new int[N + 1][M];
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < M; j++) {
+				int num = Integer.parseInt(st.nextToken());
+				if (num == 1) {
+					eCount_3.add(new Enemy(i, j)); // 초기 데이터를 입력 받으면서 적 리스트에 적 좌표를 추가
+				}
+				map[i][j] = num;
+			}
+		}
+		comb(0, 0, 0);
+		System.out.println(max_kill);
+	}
+
+	static void comb(int idx, int start, int flag) { //궁수 배치 좌표 조합 메서드
+		if (idx == 3) {
+			ArrayList<Archer> archer = new ArrayList<>();
+			int[][] map2 = new int[N + 1][M];
+			for (int i = 0; i < M; i++) {  // 뽑은 궁수 리스트 추가
+				if ((flag & 1 << i) != 0) {
+					archer.add(new Archer(N, i));
+				}
+			}
+
+			for (int i = 0; i < N + 1; i++) {
+				map2[i] = map[i].clone(); // 맵 딥 카피
+			}
+			ArrayList<Enemy> eCount_2 = new ArrayList<>();
+			eCount_2.addAll(eCount_3); //적 딥카피
+			game(archer, map2, eCount_2, 0); // 궁수조합, 딥카피한 맵,적 좌표리스트 넘겨줌
+			return;
+		}
+
+		for (int i = start; i < M; i++) {
+			comb(idx + 1, i + 1, flag | 1 << i);
+		}
+	}
+
+	static void game(ArrayList<Archer> archer, int[][] map2, ArrayList<Enemy> eCount, int enemy) { // 재귀를 돌려주며 게임진행
+		if (eCount.size() <= 0) { // 적이 다 죽었을경우
+			if (max_kill < enemy) { // 최대 킬수랑 현재 킬수 비교 후 리턴
+				max_kill = enemy;
+			}
+			return;
+		}
+		ArrayList<Enemy> shoot = new ArrayList<Enemy>(); // 궁수의 사거리 범위 안에 있는 적들을 체크할 리스트
+		for (int i = 0; i < archer.size(); i++) { // 궁수 리스트를 반복돌림
+			int max_value = Integer.MAX_VALUE;
+			Enemy shooting = null;
+			for (int j = 0; j < eCount.size(); j++) { // 적 좌표 리스트를 반복 돌림
+				int r = Math.abs(archer.get(i).x - eCount.get(j).x);  // 적과 i번째 궁수의 거리 비교 1
+				int c = Math.abs(archer.get(i).y - eCount.get(j).y);  // 적과 i번째 궁수의 거리 비교 2
+				if (r + c <= D) { // 사거리 안에 적이 있을 경우
+					if (max_value == r + c && shooting.y > eCount.get(j).y) { // 만약 현재 최소 사거리와 구한 사거리의 길이가 같을 경우 현재 적의 y좌표가 더 작을 경우 쏠 사람을 바꿔줌
+						shooting = eCount.get(j);
+					}
+					if (max_value > r + c) { // 현재 최소 사거리 보다 현재 적의 사거리가 더 짧으면 쏠 적을 바꿔줌
+						shooting = eCount.get(j);
+						max_value = r + c;
+					}
+				}
+			}
+			if (shooting != null) { //쏠 적이 있을 경우 발사 목록에 적들 좌표 넣어줌
+				shoot.add(shooting);
+			}
+		}
+
+		for (int i = 0; i < shoot.size(); i++) { // 목록에 있는 적들을 쏘면서 적 리스트의 값을 삭제하고 적 카운트 증가시켜줌
+			map2[shoot.get(i).x][shoot.get(i).y] = 0;
+			if (eCount.contains(shoot.get(i))) {
+				eCount.remove(shoot.get(i));
+				enemy++;
+			}
+		}
+
+		ArrayList<Enemy> eCount_4 = new ArrayList<>(); 
+		for (int i = 0; i < eCount.size(); i++) {
+			eCount_4.add(new Enemy(eCount.get(i).x, eCount.get(i).y));
+		}
+		for (int i = 0; i < eCount_4.size(); i++) {
+			if (eCount_4.get(i).x + 1 >= N) {
+				eCount_4.remove(i);
+				i--;
+				continue;
+			}
+			eCount_4.get(i).x += 1;
+		}
+		game(archer, map2, eCount_4, enemy); // 조건이 만족 될 때 까지 재귀
+	}
+}

--- a/ahg/220811/Gear.java
+++ b/ahg/220811/Gear.java
@@ -1,0 +1,83 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static char[][] magnet;
+	static int[][] mag_see = new int[4][2];
+	static boolean[] spine;
+
+	public static void main(String[] args) throws Exception {
+		magnet = new char[4][8];
+		for (int i = 0; i < 4; i++) {
+			magnet[i] = br.readLine().toCharArray();
+		}
+		int K = Integer.parseInt(br.readLine());
+		for (int i = 0; i < 4; i++) {
+			mag_see[i][0] = 2;
+			mag_see[i][1] = 6;
+		}
+		for (int i = 0; i < K; i++) {
+			spin();
+		}
+		int score = 0;
+		if (magnet[0][(mag_see[0][1] + 2) % 8] == '1') {
+			score += 1;
+		}
+		if (magnet[1][(mag_see[1][1] + 2) % 8] == '1') {
+			score += 2;
+		}
+		if (magnet[2][(mag_see[2][1] + 2) % 8] == '1') {
+			score += 4;
+		}
+		if (magnet[3][(mag_see[3][1] + 2) % 8] == '1') {
+			score += 8;
+		}
+		System.out.println(score);
+	}
+
+	static void spin() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		int mag_num = Integer.parseInt(st.nextToken()) - 1;
+		int direc = Integer.parseInt(st.nextToken());
+		check();
+		move(direc, mag_num);
+	}
+
+	static void move(int direc, int mag_num) {
+		if (mag_num < 0 || mag_num > 3) {
+			return;
+		}
+		if (direc == 1) {
+			if (--mag_see[mag_num][0] < 0)
+				mag_see[mag_num][0] = 7;
+			if (--mag_see[mag_num][1] < 0)
+				mag_see[mag_num][1] = 7;
+		} else {
+			mag_see[mag_num][0] = (mag_see[mag_num][0] + 1) % 8;
+			mag_see[mag_num][1] = (mag_see[mag_num][1] + 1) % 8;
+		}
+
+		if (spine[mag_num]) {
+			spine[mag_num] = false;
+			move(direc * -1, mag_num - 1);
+		}
+		if (spine[mag_num + 1]) {
+			spine[mag_num + 1] = false;
+			move(direc * -1, mag_num + 1);
+		}
+	}
+
+	static void check() {
+		spine = new boolean[5];
+		for (int i = 0; i < 3; i++) {
+			if (magnet[i][mag_see[i][0]] != magnet[i + 1][mag_see[i + 1][1]]) {
+				spine[i + 1] = true;
+			}
+		}
+	}
+}

--- a/ahg/220811/MoveThePipe.java
+++ b/ahg/220811/MoveThePipe.java
@@ -1,0 +1,67 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int N;
+	static int cnt = 0;
+	static int[][] map;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		check(0, 1, 0);
+		System.out.println(cnt);
+	}
+
+	// 파이프는 3가지의 상태
+	// 가로 ,세로,대각선
+	static void check(int x, int y, int status) {
+		if (x == N - 1 && y == N - 1) { // 파이프가 정상적으로 도착점에 도달했을 경우 카운트 증가
+			cnt++;
+			return;
+		}
+		if (status == 0) { // 가로일때는 가로와 대각선이 가능한지 체크
+			x_check(x,y);
+			xy_check(x,y);
+		}
+		if (status == 1) { // 세로 일 때는 세로와 대각선이 가능한지 체크
+			y_check(x,y);
+			xy_check(x,y);
+		}
+		if (status == 2) { // 대각선 일 때는 세방향이 가능한지 체크
+			x_check(x, y);
+			y_check(x, y);
+			xy_check(x, y);
+		}
+	}
+
+	static void x_check(int x, int y) {
+		if (y + 1 < N && map[x][y + 1] == 0) { // 가능하다면 가로로 설치했다고 가정하고 다시 check함수 호출
+			check(x, y + 1, 0);
+		}
+	}
+
+	static void y_check(int x, int y) {
+		if (x + 1 < N && map[x + 1][y] == 0) { // 가능하다면 세로로 설치했다고 가정하고 다시 check함수 호출
+			check(x + 1, y, 1);
+		}
+
+	}
+
+	static void xy_check(int x, int y) { // 가능하다면 대각선으로 설치했다고 가정하고 다시 check함수 호출
+		if (y + 1 < N && x + 1 < N && map[x + 1][y + 1] == 0 && map[x +1][y] == 0 && map[x][y+1]==0) {
+			check(x + 1, y + 1, 2);
+		}
+
+	}
+}


### PR DESCRIPTION
### 한 줄 소감
전체적으로 문제 수준이 올라가서 어려웠다.




## 1번 문제 풀이 [괄호 추가하기]
### 문제 분석
인덱스 두개를 관리해야 하는 부분집합 문제

### 걸린 시간
1시간 

### 풀이 방법
1. a+b의 연산에 대해서만 괄호가 가능하다
2. 그러니 a+b를 하나의 인덱스로 보고 괄호를 쳐주는 a+b 부분을 연산한 문자열을 반환 하는 값과 괄호를 안쳤을때의 문자열 두 경우의 수에 대해 재귀를 돌린다.
4. 하고 각각의 인덱스를 +2씩 증가시켜준다 식으로 부분집합을 수행한다.


### 포인트
괄호 안에 연산자가 반드시 하나만 들어가야 한다는 조건
문자열 안에 괄호를 추가 해주는 것 보다 괄호를 쳐야할 부분을 미리 연산해 놓는것





## 2번 문제 풀이 [⚾]
### 문제 분석
구현문제인데 평범한 구현문제라고 생각하고 풀었다가는 시간초과가 나는 문제여서 최적화가 필요하다

### 걸린 시간
4시간

### 풀이 방법
1. 1번선수를 4번타자로 고정 후 순열을 사용해 나올 수 있는 순서를 전부 봅는다
2. 뽑힌 순서로 게임을 진행하는데 삼진아웃이 되기 전 까진 계속 돌아가니 삼진아웃 전까지 무한반복을 돌린다
5. 안타를 치면 안타를 친 점수 만큼 각 루에 있는 주자들을 이동시켜준다
6. 타자를 점수만큼 이동시켜준다
7. 삼진아웃되어 이닝이 넘어갈 때에는 마지막으로 친 다음 타자부터 타석에 서야 하기에 마지막 타자 +1을 시작값으로 주고 재귀함수를 돌린다.

### 포인트
타자가 안타를 쳤을때 점수계산 로직을 최대한 단순하게 만들어주는것






## 3번 문제 풀이 [캐슬 디펜스]
### 문제 분석
조합이 들어간 시뮬레이션 문제

### 걸린 시간
1시간30분

### 풀이 방법
1. 적의 좌표를 저장하는 클래스 리스트를 만들어 적의 좌표를 저장한다
2. 조합을 통해 궁수 위치를 뽑고 궁수 목록 리스트를 생성한다
3. 거리계산 공식을 통해 제시된 거리 안에 있으면 사거리 안에 있는 다른 적들과 비교하여 더 적은 거리, 같은거리 일떈 왼쪽에 있는 적을 선택하여 좌표를 변수에 저장해준다
4. 각 궁수마다 저장한 쏠 대상의 배열을 반복을 돌리면서 적 좌표 리스트에서 삭제해준다
5. 한 턴이 끝나면 적 리스트의 좌표를 한 칸씩 내려준다
6. 적 좌표 리스트의 크기가 0이 되면 죽인 적과 현재까지 최대 죽인 적을 비교해서 최대값에 저장 한 후 출력

### 포인트
적이 같은 거리에 있을때 가장 왼쪽을 쏴야하는 로직을 구현하는 방법






## 4번 문제 풀이 [파이프 옮기기1]
### 문제 분석
단순한 dfs문제

### 걸린 시간
30분

### 풀이 방법
1. 각 파이프에 해당하는 번호를 정해준다
2. 초기엔 가로이기 떄문에 가로로 시작해서 가능한 파이프들을 dfs로 돌려주면서 도착지점에 도착하면 결과값을 +1 카운팅 해준 후 모든 탐색이 끝나면 출력

### 포인트
완전탐색의 개념을 알고 있어야 한다