### PR TITLE
[220811] 조은서

### DIFF
--- a/jes/220811/Main_G3_17135_캐슬디펜스.java
+++ b/jes/220811/Main_G3_17135_캐슬디펜스.java
@@ -1,0 +1,118 @@
+package algostudy.day0811;
+
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main_G3_17135_캐슬디펜스 {
+	static int N, M, D, max;
+	static int[][] map;
+	static int[] loc;
+	
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		D = Integer.parseInt(st.nextToken());
+		map = new int[N][M];
+	
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		loc = new int[3];
+		max = 0;
+		comb(0,0);
+		System.out.println(max);
+	}
+
+	// 궁수 위치 지정
+	private static void comb(int start, int cnt) {
+		if(cnt == 3) {
+			// 궁수 배치 완료. 최대 물리칠 수 있는 적 수 카운트
+			defence(new int[N][M]);
+			return;
+		}
+		
+		for(int i=start; i<M; i++) {
+			loc[cnt] = i;
+			comb(start+1, cnt+1);
+		}
+	}
+
+	// 가장 가까운 적 찾아 동시에 공격하고 물리친 적 카운트
+	private static void defence(int[][] map) {
+		map = mapCopy();
+		
+		int cnt = 0;
+		int turn = 0;
+		while(turn < N) {
+			// 죽인 적 겹치지 않게 카운트하기 위해 사용
+			boolean[][] isKilled = new boolean[N][M];
+			List<Point> killed = new ArrayList<>();
+			
+			for(int i = 0; i<3; i++) { // 궁수 3명 공격
+				// 가장 가까운 적 찾기
+				int dr = N-turn;
+				int dc = loc[i];
+				int min = Integer.MAX_VALUE;
+				int r = -1;
+				int c = -1;
+				
+				// 세로줄로 검사해서 적과 궁수의 거리 계산
+				for(int m = M-1; m >= 0; m--) {
+					for(int n = 0; n < N; n++) {
+						if(map[n][m] == 1) {
+							int d = Math.abs(dr-n) + Math.abs(dc-m);
+							if(d > 0 && d <= D) {
+								if(min >= d) {
+									min = d;
+									r = n;
+									c = m;
+								}
+							}
+						}
+					}
+				}
+				
+				// 가까운 적이 있을 때 이미 처리한 적은 카운트 하지 않음
+				if(r!=-1 || c!=-1) {
+					if(!isKilled[r][c]) {
+						killed.add(new Point(r, c));
+						cnt++;
+					}
+					isKilled[r][c] = true;
+				}
+			}
+			
+			for(int i=0; i<killed.size(); i++) {
+				map[killed.get(i).x][killed.get(i).y] = 0;
+			}
+			// 성으로 들어온 적 맵에서 제거
+			for(int i=0; i<M; i++)
+				map[N-turn-1][i] = 0;
+			
+			turn++;
+		}
+		
+		max = Math.max(max, cnt);
+	}
+	
+	static int[][] mapCopy() {
+		int[][] copy = new int[N][M];
+		for (int i = 0; i < N; i++) {
+			copy[i] = map[i].clone();
+		}
+		return copy;
+	}
+}

--- a/jes/220811/Main_G4_16637_괄호추가하기.java
+++ b/jes/220811/Main_G4_16637_괄호추가하기.java
@@ -1,0 +1,115 @@
+package algostudy.day0811;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeSet;
+
+public class Main_G4_16637_괄호추가하기 { // 12104kb 88ms
+	static int N, max;
+	static String[] sik;
+	static List<Integer> input; // 연산자
+	static boolean[] isSelected;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		sik = br.readLine().split("");
+		input = new ArrayList<>();
+		for(int i=0; i<sik.length; i++) {
+			if(sik[i].equals("+") || sik[i].equals("-") || sik[i].equals("*")) {
+				 input.add(i);
+			}
+		}
+		isSelected = new boolean[input.size()];
+		max = Integer.MIN_VALUE;
+		subset(0);
+		System.out.println(max);
+	}
+	private static void subset(int index) {
+		if(index == input.size()) {
+			int count= 0;
+			for(int i=0; i<input.size(); i++) {
+				if(isSelected[i]) count++;
+				if(count>=(input.size()+1)/2+1) return;
+			}
+			int prev = -2;
+			List<Integer> operator = new ArrayList<>();
+			for(int i=0; i<input.size(); i++) {
+				if(isSelected[i]) {
+					if(prev+1 != i) {
+						prev = i;
+						operator.add(input.get(i));
+					}
+					else {
+						return;
+					}
+				}
+			}
+			max = Math.max(max, operation(operator));
+			return;
+		}
+		
+		isSelected[index] = false;
+		subset(index+1);
+		isSelected[index] = true;
+		subset(index+1);
+	}
+	
+	private static int operation(List<Integer> operator) {
+		int res = 0;
+		Deque<String> q = new ArrayDeque<>();
+		boolean[] isoper = new boolean[N];
+		for(int i = 0, index = 0; i<N; i++) {
+			if(!operator.isEmpty() && i==operator.get(index) && !operator.get(index).equals(" ")) { // 우선 계산해야 되는 부분 계산
+				int a = Integer.parseInt(q.pollLast());
+				int b = Integer.parseInt(sik[operator.get(index)+1]);
+				if(sik[operator.get(index)].equals("+"))
+					q.add(String.valueOf(add(a, Integer.parseInt(sik[operator.get(index)+1]))));
+				else if(sik[operator.get(index)].equals("-")) 
+					q.add(String.valueOf(sub(a, Integer.parseInt(sik[operator.get(index)+1]))));
+				else
+					q.add(String.valueOf(mul(a, Integer.parseInt(sik[operator.get(index)+1]))));
+				isoper[operator.get(index)-1] = true;
+				isoper[operator.get(index)] = true;
+				isoper[operator.get(index)+1] = true;
+				operator.remove(0);
+			}
+			else {
+				if(!isoper[i]) q.add(sik[i]);
+			}
+		}
+		res = Integer.parseInt(q.poll()); 
+		while(!q.isEmpty()) {
+			String oper = q.poll();
+			int b = Integer.parseInt(q.poll());
+			
+			if(oper.equals("+")) res += b;
+			else if(oper.equals("-")) res -= b;
+			else res *= b;
+		}
+		
+		return res;
+	}
+	
+	private static int add(int a, int b) {
+		return a+b;
+	}
+	
+	private static int sub(int a, int b) {
+		return a-b;
+	}
+	
+	private static int mul(int a, int b) {
+		return a*b;
+	}
+}

--- a/jes/220811/Main_G4_17281_야구공.java
+++ b/jes/220811/Main_G4_17281_야구공.java
@@ -1,0 +1,94 @@
+package algostudy.day0811;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_G4_17281_야구공 { // 77688kb 488ms
+	static int N, max = 0;
+	static int[][] score;
+	static int[] order, input, loc;
+	static boolean[] isSelected;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		score = new int[N][9];
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<9; j++) {
+				score[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		input = new int[] {1, 2, 3, 4, 5, 6, 7, 8};
+		do {
+			total(input);
+		}while(np(input));
+		System.out.println(max);
+	}
+	
+	public static boolean np(int[] input) {
+		int N = input.length;
+		int i = N-1;
+		while(i>0 && input[i-1]>=input[i]) --i;
+		if(i==0) return false;
+		
+		int j = N-1;
+		while(input[i-1]>=input[j]) --j;
+		swap(input, i-1, j);
+		
+		int k = N-1;
+		while(i<k) swap(input, i++, k--);
+		return true;
+	}
+	
+	public static void swap(int[] input, int i, int j) {
+		int tmp = input[i];
+		input[i] = input[j];
+		input[j] = tmp;
+	}
+	
+	private static void total(int[] input) {
+		int[] order = new int[input.length+1];
+		order[0] = input[0];
+		order[1] = input[1];
+		order[2] = input[2];
+		order[3] = 0;
+		for(int i=4; i<9; i++) {
+			order[i] = input[i-1];
+		}
+		int i = 0;
+		int sum = 0;
+		for(int n=0; n<N; n++) {
+			loc = new int[4];
+			int out = 0;
+			while(out < 3){
+				if(score[n][order[i]]==0) out++;
+				else {
+					move(score[n][order[i]]);
+				}
+				i = (i+1) % 9;
+			}
+			sum += loc[3];
+		}
+		max = Math.max(max, sum);
+		return;
+	}
+	
+	private static void move(int num) {
+		for(int i=2; i>=0; i--) { // 3루타 ~ 1루타
+			if(loc[i]!=0) { // 이동할 선수가 있을 때
+				if(i+num < 3) { // 2, 3 루타에 남는 경우
+					loc[i+num] = 1;
+					loc[i] = 0;
+				}
+				else{ // 홈에 들어가는 경우
+					loc[3]++;
+					loc[i] = 0;
+				}	
+			}
+		}
+		if(num==4) loc[3]++; // 홈런인 경우 바로 홈에 들어가는 주자
+		else loc[num-1] = 1; // 안타, 2루타, 3루타 치고 베이스에 남는 주자
+	}
+}

--- a/jes/220811/Main_G5_14891_톱니바퀴.java
+++ b/jes/220811/Main_G5_14891_톱니바퀴.java
@@ -1,0 +1,77 @@
+package algostudy.day0811;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main_G5_14891_톱니바퀴 { // 11824kb 80ms
+	static List<Integer>[] wheel;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));		
+		StringTokenizer st;
+		
+		wheel = new ArrayList[4];
+		for(int i=0; i<4; i++) {
+			wheel[i] = new ArrayList<>();
+			String[] string = br.readLine().split("");
+			for(int j=0; j<8; j++) 
+				wheel[i].add(Integer.parseInt(string[j]));
+		}
+		
+		int K = Integer.parseInt(br.readLine()); // 회전 횟수
+		for(int i=0; i<K; i++) {
+			st = new StringTokenizer(br.readLine());
+			int num = Integer.parseInt(st.nextToken())-1; // 번호
+			int dir = Integer.parseInt(st.nextToken()); // 방향
+			rotate(num, dir);
+		}
+		
+		int res = 0;
+		if(wheel[0].get(0) == 1) res+=1;
+		if(wheel[1].get(0) == 1) res+=2;
+		if(wheel[2].get(0) == 1) res+=4;
+		if(wheel[3].get(0) == 1) res+=8;
+		System.out.println(res);
+	}
+	
+	private static void rotate(int num, int dir) {
+		// 회전 방향 구하기(리스트 수정하기 전 값으로 회전 방향 구하기 위해)
+		int[] index = new int[4];
+		index[num] = dir;
+		// num의 오른쪽 톱니바퀴
+		for(int i=num; i<3; i++) {
+			if(wheel[i].get(2)!=wheel[i+1].get(6)) {
+				index[i+1] = index[i]*(-1);
+			}
+			else {
+				index[i+1] = 0;
+				break;
+			}
+		}
+		// num의 왼쪽 톱니바퀴
+		for(int i=num; i>0; i--) {
+			if(wheel[i-1].get(2)!=wheel[i].get(6)) {
+				index[i-1] = index[i]*(-1);
+			}
+			else {
+				index[i-1] = 0;
+				break;
+			}
+		}
+		
+		// 회전
+		for(int i=num-1; i>=0; i--) {
+			if(index[i]==0) break;
+			else if(index[i]==1) wheel[i].add(0, wheel[i].remove(7));
+			else if(index[i]==-1) wheel[i].add(wheel[i].remove(0)); 
+		}
+		for(int i=num; i<4; i++) {
+			if(index[i]==0) break;
+			else if(index[i]==1) wheel[i].add(0, wheel[i].remove(7));
+			else if(index[i]==-1) wheel[i].add(wheel[i].remove(0)); 
+		}
+	}
+}

--- a/jes/220811/Main_G5_17070_파이프옮기기_1.java
+++ b/jes/220811/Main_G5_17070_파이프옮기기_1.java
@@ -1,0 +1,69 @@
+package algostudy.day0811;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_G5_17070_파이프옮기기_1 { // 12684kb 184ms
+	// 오른쪽(0), 아래(1), 오른쪽 대각선 아래(2)
+	static int[] dr = {0, 1, 1};
+	static int[] dc = {1, 0, 1};
+	static int ans, N;
+	static int[][] map;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		
+		for(int i=0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j < N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());				
+			}
+		}
+		
+		// 처음 시작하는 파이프의 오른쪽 끝점에서 시작
+		setPipe(0, 1, 0);
+		System.out.println(ans);
+	}
+	
+	public static void setPipe(int r, int c, int dir) {
+		// 도착했을 때 리턴
+		if(r == N-1 && c == N-1) {
+            ans += 1;
+            return;
+        }
+
+		// 각 방향에 따라 처리
+        if(dir == 0) {  // 가로일 때 가로, 대각선
+            if(c+1 < N && map[r][c+1] == 0) {
+            	setPipe(r, c+1, 0);
+            }
+            if(r+1 < N && c+1 < N && map[r+1][c] == 0 && map[r][c+1] == 0 && map[r+1][c+1] == 0) {
+            	setPipe(r+1, c+1, 2);
+            }
+        }
+        else if(dir == 1) {  // 세로일 때 세로, 대각선
+            if(r+1 < N && map[r+1][c] == 0) {
+            	setPipe(r+1, c, 1);
+            }
+            if(r+1 < N && c+1 < N && map[r+1][c] == 0 && map[r][c+1] == 0 && map[r+1][c+1] == 0) {
+            	setPipe(r+1, c+1, 2);
+            }
+        }
+        else {  // 대각선일 때 가로, 세로, 대각선
+            if(c+1 < N && map[r][c+1] == 0) {
+            	setPipe(r, c+1, 0);
+            }
+            if(r+1 < N && map[r+1][c] == 0) {
+            	setPipe(r+1, c, 1);
+            }
+            if(r+1 < N && c+1 < N && map[r+1][c] == 0 && map[r][c+1] == 0 && map[r+1][c+1] == 0) {
+            	setPipe(r+1, c+1, 2);
+            }
+        }
+	}
+}


### PR DESCRIPTION
### 한 줄 소감
`풀이 시간이 너무 오래걸린다 T_T 줄여보자`




## 1번 문제 풀이 [ 캐슬 디펜스 ]
### 문제 분석
- 조건
    - 적은 N x M 격자판 안에, 궁수 3명은 격자판 밖 N+1번째 줄(성)에 위치
    - 한 칸에는 한 명의 적, 한 명의 궁수만 위치
    - 여러 궁수가 같은 적 공격 가능하고 동시에 공격
    - 거리가 최소인 적을 공격하며 여러 적이 있을 때 가장 왼쪽 적부터 공격
    - 공격이 한 번 끝나면 공격받은 적 제외(0)
    - 각 턴마다 적이 한 줄 아래로 내려와서 성에 들어오면 격자판에서 사라짐(0)

### 걸린 시간
- 3시간

### 풀이 방법
- 풀이
    - 궁수의 배치를 조합으로 구한 다음 각 배치별 최대로 제거할 수 있는 적의 수 구하기
    - 궁수 1명씩 가장 가까운 적 구한 다음 카운트
    - 공격이 한 번 끝난 후 공격받은 적 제외하고 성으로 들어온 적 제외
- 막힌 부분
    - 런타임 에러: boolean isKilled 배열의 인덱스를 [N][M]으로 주어야 하는데 [N][N]으로 줌
    - 16% 틀렸습니다: 거리가 같을 때 가장 왼쪽 적부터 공격인데 오른쪽부터 공격해서 틀림
        → for문의 열 인덱스를 반대로 해주어 해결

### 포인트
- 조건을 잘읽기! 조건만 맞게 잘하면 통과였다.. 





## 2번 [ 괄호 추가하기 ]
### 문제 분석
- 조건
    - 길이가 N인 수식 숫자(0~9) 연산자(+, -, x)
    - 연산자 우선순위는 동일하다고 보고 왼쪽부터 순서대로 계산
    - 괄호는 중첩될 수 없고 괄호 안에는 하나의 연산자만 존재
    - 괄호 추가하지 않아도 되고 개수 제한 없을 때 식 결과의 최댓값을 구하는 문제

### 걸린 시간
- 1시간

### 풀이 방법
- 연산자의 위치를 리스트에 저장하고 그 리스트를 부분집합을 구함
- 괄호가 중첩되면 안되기 때문에 부분집합을 생성할 때 바로 다음 연산자를 건너뛰게 함
- 큐를 사용하여 왼쪽부터 연산하고 덱을 사용하여 우선 계산해야 되는 부분을 계산함

### 포인트
- 덱을 쓰니까 편하당!! 신기






## 3번 문제 풀이 [ 파이프 옮기기1 ]
### 문제 분석
- 집의 크기는 N x N 이고 각각의 칸은 (r, c)
- 각 칸에는 0(빈 칸) 또는 1(벽)이 있고 파이프의 크기는 2개 칸을 차지하는 크기
- 파이프는 45도 회전만 가능하고 방향은 오른쪽, 아래, 오른쪽 아래 대각선
    1. 가로일 때 → 가로, 대각선
    2. 세로일 때 → 세로, 대각선
    3. 대각선일 때 → 가로, 세로, 대각선
- 대각선의 경우 파이프 끝이 있던 칸을 포함해서 주변 4칸이 빈칸이어야 함
- 시작점은 (1, 1) (1, 2) 이고 파이프의 한쪽 끝을 (N. N)으로 이동시키는 방법의 개수 구하기

### 걸린 시간
- 40분

### 풀이 방법
- dfs 재귀를 통해 풀이
- 파이프의 방향에 따라 각각 경우의 수를 처리해주어 조건을 만족시켰음

### 포인트
- 다들 비슷하게 푼 문제였다! 이 문제도 조건에 맞게만 처리해주면 풀리는 문제





## 4번 문제 풀이 [ 야구공 ]
### 문제 분석
- 조건
    - 안타: 타자와 모든 주자가 한 루씩 진루한다.
    - 2루타: 타자와 모든 주자가 두 루씩 진루한다.
    - 3루타: 타자와 모든 주자가 세 루씩 진루한다.
    - 홈런: 타자와 모든 주자가 홈까지 진루한다.
    - 아웃: 모든 주자는 진루하지 못하고, 공격 팀에 아웃이 하나 증가한다.
    - 타순은 이닝이 변경되어도 순서를 유지
    - 한 이닝에 3아웃이 발생하면 이닝이 종료
    - 가장 많은 득점을 하는 타순을 찾고, 그 때의 득점 구하는 것이 목표!

### 걸린 시간
- 3시간
- 막힌 부분
    - 예제 1, 2, 3, 4, 6 은 잘 나오는데 예제 5, 7이 다르게 나와서 왜일까 했는데.. 결과값을 loc 배열(1루타, 2루타, 3루타, 홈에 있는 선수의 수 저장하는 배열)의 마지막 인덱스(홈)으로 계산했는데 1, 2, 3루타 중에 남아있는 값이 있었나보당..
    - 배열 초기화를 이닝마다 하도록 for문 안으로 넣으니까 되더라… 거의 2시간을 이거 찾았는데…..
  
### 풀이 방법
- 풀이
    - Next Permutation으로 먼저 자리가 이미 지정된 1번 주자를 제외한 2번~9번 주자의 순열을 구한 다음 4번째 자리에 1번 주자를 추가(새로운 배열 생성)
    - 3아웃이 되기 전까지 0이면 아웃, 0이 아니면 move()함수를 통해 선수들이 어디로 가야되는지 배치
    - loc 배열의 마지막 인덱스에 진루하여 들어온 선수의 수가 저장되어 있는데 각 경우마다 가장 큰 값을 max에 저장

### 포인트
- 초기화 하는 부분을 잘 정하자 ! ^__ㅠ